### PR TITLE
Update ZeroDenominatorException.java

### DIFF
--- a/FractionCalculator/src/ZeroDenominatorException.java
+++ b/FractionCalculator/src/ZeroDenominatorException.java
@@ -1,7 +1,148 @@
-public class ZeroDenominatorException extends Exception {
-	ZeroDenominatorException (String s) {
-		super(s);
-	}
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.songdetailstart;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.Toolbar;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.example.android.songdetailstart.content.SongUtils;
+
+import java.util.List;
+
+/**
+ * An activity representing a list of song titles (items). When one is
+ * touched, an intent starts {@link SongDetailActivity} representing
+ * song details.
+ */
+public class MainActivity extends AppCompatActivity {
+
+    /**
+     * Whether or not the activity is in two-pane mode, i.e. running on a tablet
+     * device.
+     */
+
+    /**
+     * Sets up a song list as a RecyclerView.
+     *
+     * @param savedInstanceState
+     */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_song_list);
+
+        // Set the toolbar as the app bar.
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        toolbar.setTitle(getTitle());
+
+        // Get the song list as a RecyclerView.
+        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.song_list);
+        recyclerView.setAdapter
+                (new SimpleItemRecyclerViewAdapter(SongUtils.SONG_ITEMS));
+    }
+
+    /**
+     * The ReyclerView for the song list.
+     */
+    class SimpleItemRecyclerViewAdapter
+            extends RecyclerView.Adapter
+            <SimpleItemRecyclerViewAdapter.ViewHolder> {
+
+        private final List<SongUtils.Song> mValues;
+
+        SimpleItemRecyclerViewAdapter(List<SongUtils.Song> items) {
+            mValues = items;
+        }
+
+        /**
+         * This method inflates the layout for the song list.
+         * @param parent ViewGroup into which the new view will be added.
+         * @param viewType The view type of the new View.
+         * @return
+         */
+        @Override
+        public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+            View view = LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.song_list_content, parent, false);
+            return new ViewHolder(view);
+        }
+
+        /**
+         * This method implements a listener with setOnClickListener().
+         * When the user taps a song title, the code checks if mTwoPane
+         * is true, and if so uses a fragment to show the song detail.
+         * If mTwoPane is not true, it starts SongDetailActivity
+         * using an intent with extra data about which song title was selected.
+         *
+         * @param holder   ViewHolder
+         * @param position Position of the song in the array.
+         */
+        @Override
+        public void onBindViewHolder(final ViewHolder holder, int position) {
+            holder.mItem = mValues.get(position);
+            holder.mIdView.setText(String.valueOf(position + 1));
+            holder.mContentView.setText(mValues.get(position).song_title);
+            holder.mView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    Context context = v.getContext();
+                    Intent intent = new Intent(context,
+                            SongDetailActivity.class);
+                    intent.putExtra(SongUtils.SONG_ID_KEY,
+                            holder.getAdapterPosition());
+                    context.startActivity(intent);
+                }
+            });
+        }
+
+        /**
+         * Get the count of song list items.
+         * @return
+         */
+        @Override
+        public int getItemCount() {
+            return mValues.size();
+        }
+
+        /**
+         * ViewHolder describes an item view and metadata about its place
+         * within the RecyclerView.
+         */
+        class ViewHolder extends RecyclerView.ViewHolder {
+            final View mView;
+            final TextView mIdView;
+            final TextView mContentView;
+            SongUtils.Song mItem;
+
+            ViewHolder(View view) {
+                super(view);
+                mView = view;
+                mIdView = (TextView) view.findViewById(R.id.id);
+                mContentView = (TextView) view.findViewById(R.id.content);
+            }
+        }
+    }
 }
-
-

--- a/FractionCalculator/src/ZeroDenominatorException.java
+++ b/FractionCalculator/src/ZeroDenominatorException.java
@@ -1,5 +1,3 @@
-
-
 public class ZeroDenominatorException extends Exception {
 	ZeroDenominatorException (String s) {
 		super(s);


### PR DESCRIPTION


#### What has been done to verify that this works as intended?
1. Checks if the app is crashing on clicking received forms 
2. Checked any new warnings are produced
3. Whether it is directing to review form 

#### Why is this the best possible solution? Were any other approaches considered?
The app is crashing due to `android.support.design.widget.TextInputLayout` so I imported dependencies from `google android material` 
and stopped the warning of `autofill`


#### How does this change affect users? 
App crash is not at all the good behavior, so removed that behavior
by directing into review form so the user can review the forms or view it on ODK collect 

### GIF
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/48018942/55570270-b47a6180-5720-11e9-8b49-145d3669da88.gif)


#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).